### PR TITLE
 Customize close button in WeatherTooltip

### DIFF
--- a/src/components/HistoryPanel/HistoryPanel.module.css
+++ b/src/components/HistoryPanel/HistoryPanel.module.css
@@ -25,15 +25,15 @@
   justify-content: space-between;
   align-items: center;
   padding: 5px 0;
-  /* border-bottom: 1px solid #eee; */
-  /* color: black; */
+  border-bottom: 1px solid #eee;
+  color: black;
 }
 .closeIcon {
   color: #5f6368;
   border: none;
   cursor: pointer;
   padding: 3px 5px;
-  font-size: 20px;
+  font-size: 1.5rem;
 }
 .closeIcon:hover {
   color: #d32f2f;

--- a/src/components/WeatherTooltip/WeatherTooltip.jsx
+++ b/src/components/WeatherTooltip/WeatherTooltip.jsx
@@ -1,10 +1,32 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { InfoWindow } from "@react-google-maps/api";
 import styles from "./WeatherTooltip.module.css";
 
 export default function WeatherTooltip({ position, weather, onClose }) {
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      const closeButton = document.querySelector(".gm-ui-hover-effect");
+
+      if (closeButton) {
+        closeButton.style.fontSize = "16px";
+        closeButton.style.color = "#5f6368";
+        closeButton.style.width = "40px";
+        closeButton.style.height = "24px";
+        closeButton.style.border = "none";
+        closeButton.style.cursor = "pointer";
+
+        clearInterval(intervalId);
+      }
+    }, 100);
+  }, []);
+
   return (
-    <InfoWindow position={position} onCloseClick={onClose}>
+    <InfoWindow
+      position={position}
+      onCloseClick={onClose}
+      options={{ pixelOffset: new window.google.maps.Size(0, -30) }}
+      className={styles.customInfowindow}
+    >
       <div className={styles.weatherTooltip}>
         <h3 className={styles.weatherTitle}>Weather Information</h3>
         <p className={styles.weatherDetail}>


### PR DESCRIPTION
Customize close button in WeatherTooltip
- Add useEffect to apply custom styles to the close button in InfoWindow component from @react-google-maps/api.
- Adjust close button styles: increased font size, changed color, set width and height, removed border, and set cursor to pointer.
