### PR TITLE
1. Added a new prop onSelect to the HistoryPanel component, which all…

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -70,7 +70,11 @@ function App() {
                     setSelectedPosition={setSelectedPosition}
                     weather={weather}
                   />
-                  <HistoryPanel history={history} onDelete={deleteHistory} />
+                  <HistoryPanel
+                    history={history}
+                    onDelete={deleteHistory}
+                    onSelect={handleSelectLocation}
+                  />
                 </>
               }
             />

--- a/src/components/HistoryPanel/HistoryPanel.jsx
+++ b/src/components/HistoryPanel/HistoryPanel.jsx
@@ -1,15 +1,21 @@
 import React from "react";
 import styles from "./HistoryPanel.module.css";
 
-export default function HistoryPanel({ history, onDelete }) {
+export default function HistoryPanel({ history, onDelete, onSelect }) {
   return (
     <div className={styles.historyPanel}>
       <h3 className={styles.historyTitle}>History</h3>
       <ul className={styles.historyList}>
         {history.map((point, index) => (
-          <li key={index} className={styles.historyItem}>
+          <li key={index} className={styles.historyItem} onClick={() => onSelect(point)}>
             {point.label}
-            <span onClick={() => onDelete(index)} className={styles.closeIcon}>
+            <span
+              onClick={(e) => {
+                e.stopPropagation(e);
+                onDelete(index);
+              }}
+              className={styles.closeIcon}
+            >
               &times;
             </span>
           </li>

--- a/src/components/HistoryPanel/HistoryPanel.module.css
+++ b/src/components/HistoryPanel/HistoryPanel.module.css
@@ -27,6 +27,7 @@
   padding: 5px 0;
   border-bottom: 1px solid #eee;
   color: black;
+  cursor: pointer;
 }
 .closeIcon {
   color: #5f6368;


### PR DESCRIPTION
1. Added a new prop onSelect to the HistoryPanel component, which allows you to handle clicks on history elements.
 - Each item in the history list now has an onClick event handler that calls onSelect with the selected location.
 - Used e.stopPropagation() to prevent onSelect from being called when the delete cross is clicked.

2. Updated the App component to pass the handleSelectLocation function as an onSelect prop to the HistoryPanel component.
 - This ensures that the map automatically moves to the appropriate location when clicking on a story item.

3. Updated the deleteHistor function in the App component to delete the selected item from the history.
 - Added an event handler for the delete cross that calls onDelete and prevents onSelect from firing.

The changes allow users to click on locations in the story and automatically navigate to those locations on the map.